### PR TITLE
Fix the behavior of BroadPhaseCollisionFilter

### DIFF
--- a/docs/docs/02_documentation/04contact-generation.md
+++ b/docs/docs/02_documentation/04contact-generation.md
@@ -45,7 +45,7 @@ public class TeamFilter : IBroadPhaseFilter
         }
 
         // There is no collision between team red and team blue.
-        return shapeA.RigidBody.Tag == shapeB.RigidBody.Tag;
+        return shapeA.RigidBody.Tag != shapeB.RigidBody.Tag;
     }
 }
 ```

--- a/src/Jitter2/SoftBodies/BroadPhaseCollisionFilter.cs
+++ b/src/Jitter2/SoftBodies/BroadPhaseCollisionFilter.cs
@@ -38,7 +38,7 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
 
     public bool Filter(Shape shapeA, Shape shapeB)
     {
-        if (!world.Shapes.IsActive(shapeA) && !world.Shapes.IsActive(shapeB)) return true;
+        if (!world.Shapes.IsActive(shapeA) && !world.Shapes.IsActive(shapeB)) return false;
 
         ISoftBodyShape? i1 = shapeA as ISoftBodyShape;
         ISoftBodyShape? i2 = shapeB as ISoftBodyShape;
@@ -49,7 +49,7 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
                 JMatrix.Identity, JVector.Zero,
                 out JVector pA, out JVector pB, out JVector normal, out float penetration);
 
-            if (!colliding) return true;
+            if (!colliding) return false;
 
             var closestA = i1.GetClosest(pA);
             var closestB = i2.GetClosest(pB);
@@ -57,7 +57,7 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
             world.RegisterContact(closestA.RigidBodyId, closestB.RigidBodyId, closestA, closestB,
                 pA, pB, normal, penetration);
 
-            return true;
+            return false;
         }
 
         if (i1 != null)
@@ -65,14 +65,14 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
             bool colliding = NarrowPhase.MPREPA(shapeA, shapeB, shapeB.RigidBody!.Orientation, shapeB.RigidBody.Position,
                 out JVector pA, out JVector pB, out JVector normal, out float penetration);
 
-            if (!colliding) return true;
+            if (!colliding) return false;
 
             var closest = i1.GetClosest(pA);
 
             world.RegisterContact(closest.RigidBodyId, shapeB.RigidBody.RigidBodyId, closest, shapeB.RigidBody,
                 pA, pB, normal, penetration);
 
-            return true;
+            return false;
         }
 
         if (i2 != null)
@@ -80,16 +80,16 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
             bool colliding = NarrowPhase.MPREPA(shapeB, shapeA, shapeA.RigidBody!.Orientation, shapeA.RigidBody.Position,
                 out JVector pA, out JVector pB, out JVector normal, out float penetration);
 
-            if (!colliding) return true;
+            if (!colliding) return false;
 
             var closest = i2.GetClosest(pA);
 
             world.RegisterContact(closest.RigidBodyId, shapeA.RigidBody.RigidBodyId, closest, shapeA.RigidBody,
                 pA, pB, normal, penetration);
 
-            return true;
+            return false;
         }
 
-        return false;
+        return true;
     }
 }

--- a/src/Jitter2/World.Detect.cs
+++ b/src/Jitter2/World.Detect.cs
@@ -269,7 +269,7 @@ public partial class World
 
         if (BroadPhaseFilter != null)
         {
-            if (BroadPhaseFilter.Filter(sA, sB))
+            if (!BroadPhaseFilter.Filter(sA, sB))
             {
                 return;
             }


### PR DESCRIPTION
https://github.com/notgiven688/jitterphysics2/issues/56

IBroadPhaseFilter was implemented wrong:

|     **Filter**     | **To drop [code]** | **To drop [docs]** |
|:------------------:|--------------------|--------------------|
| IBroadPhaseFilter  | _True_               | False              |
| INarrowPhaseFilter | False              | False              |
| DynamicTree.Filter | False              | False              |