### PR TITLE
Added GetHashCode in TriangleMesh.cs. TriangleMesh was O(n^2) due to hash collisions.

### DIFF
--- a/src/Jitter2/Collision/TriangleMesh.cs
+++ b/src/Jitter2/Collision/TriangleMesh.cs
@@ -62,6 +62,11 @@ public class TriangleMesh
             IndexA = indexA;
             IndexB = indexB;
         }
+
+        public override int GetHashCode()
+        {
+            return IndexA + 228771 * IndexB;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
|                Method | NumProbes |         Mean | Error |
|---------------------- |---------- |-------------:|------:|
| TestHashCollisionRate |      1000 |     45.27 ms |    NA |
| TestHashCollisionRate |     10000 |    746.93 ms |    NA |
| TestHashCollisionRate |    100000 | 51,242.25 ms |    NA |

With GetHashCode:

|                Method | NumProbes |      Mean | Error |
|---------------------- |---------- |----------:|------:|
| TestHashCollisionRate |      1000 |  3.426 ms |    NA |
| TestHashCollisionRate |     10000 |  5.419 ms |    NA |
| TestHashCollisionRate |    100000 | 15.842 ms |    NA |


```
using BenchmarkDotNet.Engines;

BenchmarkRunner.Run<GenericTest>();

[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 0, iterationCount : 1, invocationCount : 1)]
public class GenericTest
{
    [Params(1000, 10_000, 100_000)]
    public int NumProbes { get; set; }

    [Benchmark]
    public void TestHashCollisionRate()
    {
        Dictionary<TriangleMesh.Edge, int> dictHashes = new();

        for (int i = 0; i < NumProbes; i++)
        {
            TriangleMesh.Edge e;
            e.IndexA = i;
            e.IndexB = i + 1;
            dictHashes.TryAdd(e, i);
        }
    }
}
```