### PR TITLE
 Call World.DynamicTree.RemoveProxy(shape) before detaching the rigid…

### DIFF
--- a/src/Jitter2/Dynamics/RigidBody.cs
+++ b/src/Jitter2/Dynamics/RigidBody.cs
@@ -453,8 +453,9 @@ public sealed class RigidBody : IListIndex, IDebugDrawable
             World.Remove(tr);
         }
 
+        World.DynamicTree.RemoveProxy(shape);
         shape.DetachRigidBody();
-        World.Remove(shape);
+        World.InternalRemoveShape(shape);
 
         if (setMassInertia) SetMassInertia();
     }

--- a/src/Jitter2/World.cs
+++ b/src/Jitter2/World.cs
@@ -273,8 +273,9 @@ public partial class World
 
         foreach (var shape in body.Shapes)
         {
+            DynamicTree.RemoveProxy(shape);
+            shapes.Remove(shape);
             shape.DetachRigidBody();
-            Remove(shape);
         }
 
         foreach (var contact in body.Contacts)
@@ -335,6 +336,11 @@ public partial class World
         Arbiter.Pool.Push(arbiter);
 
         arbiter.Handle = JHandle<ContactData>.Zero;
+    }
+
+    internal void InternalRemoveShape(Shape shape)
+    {
+        shapes.Remove(shape);
     }
 
     internal void UpdateShape(Shape shape)

--- a/src/JitterTests/AddRemoveTests.cs
+++ b/src/JitterTests/AddRemoveTests.cs
@@ -10,6 +10,56 @@ public class AddRemoveTests
         world = new World(100, 100, 100);
     }
 
+    class FilterOut : IBroadPhaseFilter
+    {
+        private readonly Shape shape;
+        public FilterOut(Shape shape)
+        {
+            this.shape = shape;
+        }
+
+        public bool Filter(Shape shapeA, Shape shapeB)
+        {
+            return shapeA != shape && shapeB != shape;
+        }
+    }
+
+    [TestCase]
+    public void RemoveStaticShape1()
+    {
+        Shape staticShape = new BoxShape(1000);
+        world.AddShape(staticShape);
+
+        var body = world.CreateRigidBody();
+        body.AddShape(new SphereShape(1));
+
+        world.BroadPhaseFilter = new FilterOut(staticShape);
+
+        world.Step(0.01f);
+        Assert.That(world.DynamicTree.PotentialPairs.Count == 1);
+
+        world.Clear();
+        Assert.That(world.DynamicTree.PotentialPairs.Count == 0);
+    }
+
+    [TestCase]
+    public void RemoveStaticShape0()
+    {
+        Shape staticShape = new BoxShape(1000);
+        world.AddShape(staticShape);
+
+        var body = world.CreateRigidBody();
+        body.AddShape(new SphereShape(1));
+
+        world.BroadPhaseFilter = new FilterOut(staticShape);
+
+        world.Step(0.01f);
+        Assert.That(world.DynamicTree.PotentialPairs.Count == 1);
+
+        world.Remove(body);
+        Assert.That(world.DynamicTree.PotentialPairs.Count == 0);
+    }
+
     [TestCase]
     public void AddRemoveShapes()
     {


### PR DESCRIPTION
… body to prevent the collision filter from returning a different result