### PR TITLE
Body.sleepTime uses Infinities + can create sleeping Body

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,7 @@
 .vscode
+.idea
+*.DotSettings.user
+
 imgui.ini
 [Bb]in/
 [Oo]bj/

--- a/src/Jitter2/World.cs
+++ b/src/Jitter2/World.cs
@@ -436,7 +436,7 @@ public partial class World
 
     internal void DeactivateBodyNextStep(RigidBody body)
     {
-        body.sleepTime = float.MaxValue / 2.0f;
+        body.sleepTime = float.PositiveInfinity;
     }
 
     /// <summary>
@@ -477,17 +477,19 @@ public partial class World
     /// <summary>
     /// Creates and adds a new rigid body to the simulation world.
     /// </summary>
+    /// <param name="active">initial activation state of the body.</param>
     /// <returns>A newly created instance of <see cref="RigidBody"/>.</returns>
-    public RigidBody CreateRigidBody()
+    public RigidBody CreateRigidBody(bool active = true)
     {
-        RigidBody body = new(memRigidBodies.Allocate(true, true), this);
-        body.Data.IsActive = true;
+        RigidBody body = new(memRigidBodies.Allocate(active, true), this);
+        body.Data.IsActive = active;
+        body.sleepTime = active ? 0 : float.PositiveInfinity;
 
-        bodies.Add(body, true);
+        bodies.Add(body, active);
 
         IslandHelper.BodyAdded(islands, body);
 
-        AddToActiveList(body.island);
+        if (active) AddToActiveList(body.island);
 
         return body;
     }

--- a/src/JitterTests/ActivationTests.cs
+++ b/src/JitterTests/ActivationTests.cs
@@ -1,0 +1,67 @@
+﻿namespace JitterTests;
+
+public class ActivationTests
+{
+    private World world = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        world = new World(79, 93, 67);
+    }
+
+    [TestCase]
+    public void Can_Create_Active_Body()
+    {
+        var body = world.CreateRigidBody(true);
+        Assert.That(body.IsActive);
+    }
+
+    [TestCase]
+    public void Can_Create_Sleeping_Body()
+    {
+        var body = world.CreateRigidBody(false);
+        Assert.That(!body.IsActive);
+
+        //7 days, 7 nights
+        world.Step(TimeSpan.FromDays(7).Seconds);
+        Assert.That(!body.IsActive);
+
+        //and snow-white slept for 300 years
+        world.Step(TimeSpan.FromDays(300 * 365).Seconds);
+        Assert.That(!body.IsActive);
+    }
+
+    [TestCase]
+    public void Body_Is_Active_By_Default()
+    {
+        var body = world.CreateRigidBody();
+        Assert.That(body.IsActive);
+    }
+
+    [TestCase]
+    public void Sleeping_Body_Stays_Asleep()
+    {
+        var body = world.CreateRigidBody(false);
+
+        //are you sleeping?
+        world.Step(0);
+        Assert.That(!body.IsActive);
+
+        //what if you blink?
+        world.Step(0.016f);
+        Assert.That(!body.IsActive);
+
+        //7 days, 7 nights
+        world.Step(TimeSpan.FromDays(7).Seconds);
+        Assert.That(!body.IsActive);
+
+        //and snow-white slept for 300 years...
+        world.Step(TimeSpan.FromDays(300 * 365).Seconds);
+        Assert.That(!body.IsActive);
+        
+        //until the end of time
+        world.Step(float.MaxValue);
+        Assert.That(!body.IsActive);
+    }
+}


### PR DESCRIPTION
RigidBodies can now be created InActive via optional boolean parameter to `World.CreateRigidBody(...)`, which defaults to `true`, the former behaviour.

RigidBodies track their sleep time using `float.PositiveInfinity` when deactivated, ensuring they really never wake up on their own.

Unit Test Cases added in `ActivationTests.cs`