### PR TITLE
Switch to JQuaternion for orientations

### DIFF
--- a/src/Jitter2/Collision/NarrowPhase/MinkowskiDifference.cs
+++ b/src/Jitter2/Collision/NarrowPhase/MinkowskiDifference.cs
@@ -34,13 +34,13 @@ namespace Jitter2.Collision;
 public struct MinkowskiDifference
 {
     public ISupportMap SupportA, SupportB;
-    public JMatrix OrientationB;
+    public JQuaternion OrientationB;
     public JVector PositionB;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private readonly void SupportMapTransformedRelative(in JVector direction, out JVector result)
     {
-        JVector.TransposedTransform(direction, OrientationB, out JVector tmp);
+        JVector.ConjugatedTransform(direction, OrientationB, out JVector tmp);
         SupportB.SupportMap(tmp, out result);
         JVector.Transform(result, OrientationB, out result);
         JVector.Add(result, PositionB, out result);

--- a/src/Jitter2/Collision/NarrowPhase/NarrowPhase.cs
+++ b/src/Jitter2/Collision/NarrowPhase/NarrowPhase.cs
@@ -650,7 +650,7 @@ public static class NarrowPhase
     /// hit, this parameter will be zero.
     /// </param>
     /// <returns>Returns true if the ray intersects with the shape; otherwise, false.</returns>
-    public static bool RayCast(ISupportMap support, in JMatrix orientation,
+    public static bool RayCast(ISupportMap support, in JQuaternion orientation,
         in JVector position, in JVector origin, in JVector direction, out float fraction, out JVector normal)
     {
         // rotate the ray into the reference frame of bodyA..
@@ -712,7 +712,7 @@ public static class NarrowPhase
     /// failure, collision information reverts to the type's default values.
     /// </returns>
     public static bool GJKEPA(ISupportMap supportA, ISupportMap supportB,
-        in JMatrix orientationA, in JMatrix orientationB,
+        in JQuaternion orientationA, in JQuaternion orientationB,
         in JVector positionA, in JVector positionB,
         out JVector pointA, out JVector pointB, out JVector normal, out float penetration)
     {
@@ -721,9 +721,9 @@ public static class NarrowPhase
         mkd.SupportB = supportB;
 
         // rotate into the reference frame of bodyA..
-        JMatrix.TransposedMultiply(orientationA, orientationB, out mkd.OrientationB);
+        JQuaternion.ConjugateMultiply(orientationA, orientationB, out mkd.OrientationB);
         JVector.Subtract(positionB, positionA, out mkd.PositionB);
-        JVector.TransposedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
+        JVector.ConjugatedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
 
         // ..perform collision detection..
         bool success = solver.SolveGJKEPA(mkd, out pointA, out pointB, out normal, out penetration);
@@ -761,7 +761,7 @@ public static class NarrowPhase
     /// <param name="penetration">The penetration depth.</param>
     /// <returns>Returns true if the shapes overlap (collide), and false otherwise.</returns>
     public static bool MPREPA(ISupportMap supportA, ISupportMap supportB,
-        in JMatrix orientationA, in JMatrix orientationB,
+        in JQuaternion orientationA, in JQuaternion orientationB,
         in JVector positionA, in JVector positionB,
         out JVector pointA, out JVector pointB, out JVector normal, out float penetration)
     {
@@ -770,9 +770,9 @@ public static class NarrowPhase
         mkd.SupportB = supportB;
 
         // rotate into the reference frame of bodyA..
-        JMatrix.TransposedMultiply(orientationA, orientationB, out mkd.OrientationB);
+        JQuaternion.ConjugateMultiply(orientationA, orientationB, out mkd.OrientationB);
         JVector.Subtract(positionB, positionA, out mkd.PositionB);
-        JVector.TransposedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
+        JVector.ConjugatedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
 
         // ..perform collision detection..
         bool res = solver.SolveMPR(mkd, out pointA, out pointB, out normal, out penetration);
@@ -808,7 +808,7 @@ public static class NarrowPhase
     /// <param name="penetration">The penetration depth.</param>
     /// <returns>Returns true if the shapes overlap (collide), and false otherwise.</returns>
     public static bool MPREPA(ISupportMap supportA, ISupportMap supportB,
-        in JMatrix orientationB, in JVector positionB,
+        in JQuaternion orientationB, in JVector positionB,
         out JVector pointA, out JVector pointB, out JVector normal, out float penetration)
     {
         Unsafe.SkipInit(out MinkowskiDifference mkd);
@@ -832,7 +832,7 @@ public static class NarrowPhase
     /// <param name="fraction">Time of impact. Infinity if no hit is detected.</param>
     /// <returns>True if the shapes hit, false otherwise.</returns>
     public static bool SweepTest(ISupportMap supportA, ISupportMap supportB,
-        in JMatrix orientationA, in JMatrix orientationB,
+        in JQuaternion orientationA, in JQuaternion orientationB,
         in JVector positionA, in JVector positionB,
         in JVector sweepA, in JVector sweepB,
         out JVector pointA, out JVector pointB, out JVector normal, out float fraction)
@@ -843,13 +843,13 @@ public static class NarrowPhase
         mkd.SupportB = supportB;
 
         // rotate into the reference frame of bodyA..
-        JMatrix.TransposedMultiply(orientationA, orientationB, out mkd.OrientationB);
+        JQuaternion.ConjugateMultiply(orientationA, orientationB, out mkd.OrientationB);
         JVector.Subtract(positionB, positionA, out mkd.PositionB);
-        JVector.TransposedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
+        JVector.ConjugatedTransform(mkd.PositionB, orientationA, out mkd.PositionB);
 
         // we also transform the relative velocities
         JVector sweep = sweepB - sweepA;
-        JVector.TransposedTransform(sweep, orientationA, out sweep);
+        JVector.ConjugatedTransform(sweep, orientationA, out sweep);
 
         // ..perform toi calculation
         bool res = solver.SweepTest(ref mkd, sweep, out pointA, out pointB, out normal, out fraction);
@@ -880,7 +880,7 @@ public static class NarrowPhase
     /// <param name="fraction">Time of impact. Infinity if no hit is detected.</param>
     /// <returns>True if the shapes hit, false otherwise.</returns>
     public static bool SweepTest(ISupportMap supportA, ISupportMap supportB,
-        in JMatrix orientationB, in JVector positionB, in JVector sweepB,
+        in JQuaternion orientationB, in JVector positionB, in JVector sweepB,
         out JVector pointA, out JVector pointB, out JVector normal, out float fraction)
     {
         Unsafe.SkipInit(out MinkowskiDifference mkd);

--- a/src/Jitter2/Collision/Shapes/BoxShape.cs
+++ b/src/Jitter2/Collision/Shapes/BoxShape.cs
@@ -85,16 +85,13 @@ public class BoxShape : Shape
         result.Z = Math.Sign(direction.Z) * halfSize.Z;
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
-        JMatrix.Absolute(in orientation, out JMatrix abs);
-        JVector.Transform(halfSize, abs, out JVector temp);
+        JMatrix.Absolute(JMatrix.CreateFromQuaternion(orientation), out JMatrix absm);
+        var ths = JVector.Transform(halfSize, absm);
 
-        box.Max = temp;
-        JVector.Negate(temp, out box.Min);
-
-        JVector.Add(box.Min, position, out box.Min);
-        JVector.Add(box.Max, position, out box.Max);
+        box.Min = position - ths;
+        box.Max = position + ths;
     }
 
     public override void CalculateMassInertia(out JMatrix inertia, out JVector com, out float mass)

--- a/src/Jitter2/Collision/Shapes/CapsuleShape.cs
+++ b/src/Jitter2/Collision/Shapes/CapsuleShape.cs
@@ -89,9 +89,9 @@ public class CapsuleShape : Shape
         result.Y += MathF.Sign(direction.Y) * halfLength;
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
-        JVector delta = halfLength * orientation.GetColumn(1);
+        JVector delta = halfLength * orientation.GetBasisY();
 
         box.Min.X = -radius - MathF.Abs(delta.X);
         box.Min.Y = -radius - MathF.Abs(delta.Y);

--- a/src/Jitter2/Collision/Shapes/ConeShape.cs
+++ b/src/Jitter2/Collision/Shapes/ConeShape.cs
@@ -100,11 +100,11 @@ public class ConeShape : Shape
         }
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         const float ZeroEpsilon = 1e-12f;
 
-        JVector upa = orientation.GetColumn(1);
+        JVector upa = orientation.GetBasisY();
 
         float xx = upa.X * upa.X;
         float yy = upa.Y * upa.Y;

--- a/src/Jitter2/Collision/Shapes/ConvexHullShape.cs
+++ b/src/Jitter2/Collision/Shapes/ConvexHullShape.cs
@@ -254,12 +254,13 @@ public class ConvexHullShape : Shape
         com *= 1.0f / mass;
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         JVector halfSize = 0.5f * (initBox.Max - initBox.Min);
         JVector center = 0.5f * (initBox.Max + initBox.Min);
 
-        JMatrix.Absolute(in orientation, out JMatrix abs);
+        JMatrix ori = JMatrix.CreateFromQuaternion(orientation);
+        JMatrix.Absolute(in ori, out JMatrix abs);
         JVector.Transform(halfSize, abs, out JVector temp);
         JVector.Transform(center, orientation, out JVector temp2);
 

--- a/src/Jitter2/Collision/Shapes/CylinderShape.cs
+++ b/src/Jitter2/Collision/Shapes/CylinderShape.cs
@@ -90,11 +90,11 @@ public class CylinderShape : Shape
         }
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         const float ZeroEpsilon = 1e-12f;
 
-        JVector upa = orientation.GetColumn(1);
+        JVector upa = orientation.GetBasisY();
 
         float xx = upa.X * upa.X;
         float yy = upa.Y * upa.Y;

--- a/src/Jitter2/Collision/Shapes/Shape.cs
+++ b/src/Jitter2/Collision/Shapes/Shape.cs
@@ -139,7 +139,7 @@ public abstract class Shape : ISupportMap, IListIndex, IDynamicTreeProxy
     {
         if (RigidBody == null)
         {
-            CalculateBoundingBox(JMatrix.Identity, JVector.Zero, out JBBox box);
+            CalculateBoundingBox(JQuaternion.Identity, JVector.Zero, out JBBox box);
             WorldBoundingBox = box;
         }
         else
@@ -203,9 +203,10 @@ public abstract class Shape : ISupportMap, IListIndex, IDynamicTreeProxy
     /// <see cref="SupportMap"/> function. Child classes should override this implementation to improve
     /// performance.
     /// </summary>
-    public virtual void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public virtual void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
-        JMatrix oriT = JMatrix.Transpose(orientation);
+        // TODO: Can this be done smarter?
+        JMatrix oriT = JMatrix.Transpose(JMatrix.CreateFromQuaternion(orientation));
 
         SupportMap(oriT.GetColumn(0), out JVector res);
         box.Max.X = JVector.Dot(oriT.GetColumn(0), res);

--- a/src/Jitter2/Collision/Shapes/SphereShape.cs
+++ b/src/Jitter2/Collision/Shapes/SphereShape.cs
@@ -64,7 +64,7 @@ public class SphereShape : Shape
         JVector.Multiply(result, radius, out result);
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         box.Min.X = -radius;
         box.Min.Y = -radius;

--- a/src/Jitter2/Collision/Shapes/TransformedShape.cs
+++ b/src/Jitter2/Collision/Shapes/TransformedShape.cs
@@ -116,7 +116,7 @@ public class TransformedShape : Shape
         }
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         if (type == TransformationType.General)
         {
@@ -125,7 +125,8 @@ public class TransformedShape : Shape
         }
         else
         {
-            OriginalShape.CalculateBoundingBox(orientation * this.transformation,
+            JQuaternion quat = JQuaternion.CreateFromMatrix(this.transformation);
+            OriginalShape.CalculateBoundingBox(orientation * quat,
                 JVector.Transform(translation, orientation) + position, out box);
         }
     }

--- a/src/Jitter2/Collision/Shapes/TriangleShape.cs
+++ b/src/Jitter2/Collision/Shapes/TriangleShape.cs
@@ -78,7 +78,7 @@ public class TriangleShape : Shape
 
         if (RigidBody == null) return;
 
-        ref JMatrix orientation = ref RigidBody.Data.Orientation;
+        ref JQuaternion orientation = ref RigidBody.Data.Orientation;
         ref JVector position = ref RigidBody.Data.Position;
 
         JVector.Transform(a, orientation, out a);
@@ -90,7 +90,7 @@ public class TriangleShape : Shape
         c += position;
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         const float extraMargin = 0.01f;
 

--- a/src/Jitter2/Dynamics/Constraints/AngularMotor.cs
+++ b/src/Jitter2/Dynamics/Constraints/AngularMotor.cs
@@ -81,8 +81,8 @@ public unsafe class AngularMotor : Constraint
         axis1.Normalize();
         axis2.Normalize();
 
-        JVector.TransposedTransform(axis1, body1.Orientation, out data.LocalAxis1);
-        JVector.TransposedTransform(axis2, body2.Orientation, out data.LocalAxis2);
+        JVector.ConjugatedTransform(axis1, body1.Orientation, out data.LocalAxis1);
+        JVector.ConjugatedTransform(axis2, body2.Orientation, out data.LocalAxis2);
 
         data.MaxForce = 0;
         data.Velocity = 0;

--- a/src/Jitter2/Dynamics/Constraints/BallSocket.cs
+++ b/src/Jitter2/Dynamics/Constraints/BallSocket.cs
@@ -86,8 +86,8 @@ public unsafe class BallSocket : Constraint
         JVector.Subtract(anchor, body1.Position, out data.LocalAnchor1);
         JVector.Subtract(anchor, body2.Position, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
-        JVector.TransposedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
+        JVector.ConjugatedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
+        JVector.ConjugatedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
 
         data.BiasFactor = 0.2f;
         data.Softness = 0.00f;

--- a/src/Jitter2/Dynamics/Constraints/ConeLimit.cs
+++ b/src/Jitter2/Dynamics/Constraints/ConeLimit.cs
@@ -85,8 +85,8 @@ public unsafe class ConeLimit : Constraint
 
         axis.Normalize();
 
-        JVector.TransposedTransform(axis, body1.Orientation, out data.LocalAxis1);
-        JVector.TransposedTransform(axis, body2.Orientation, out data.LocalAxis2);
+        JVector.ConjugatedTransform(axis, body1.Orientation, out data.LocalAxis1);
+        JVector.ConjugatedTransform(axis, body2.Orientation, out data.LocalAxis2);
 
         data.Softness = 0.001f;
         data.BiasFactor = 0.2f;

--- a/src/Jitter2/Dynamics/Constraints/DistanceLimit.cs
+++ b/src/Jitter2/Dynamics/Constraints/DistanceLimit.cs
@@ -96,8 +96,8 @@ public unsafe class DistanceLimit : Constraint
         JVector.Subtract(anchor1, body1.Position, out data.LocalAnchor1);
         JVector.Subtract(anchor2, body2.Position, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
-        JVector.TransposedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
+        JVector.ConjugatedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
+        JVector.ConjugatedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
 
         data.Softness = 0.001f;
         data.BiasFactor = 0.2f;
@@ -113,7 +113,7 @@ public unsafe class DistanceLimit : Constraint
             ref DistanceLimitData data = ref handle.Data;
             ref RigidBodyData body1 = ref data.Body1.Data;
             JVector.Subtract(value, body1.Position, out data.LocalAnchor1);
-            JVector.TransposedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
+            JVector.ConjugatedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
         }
         get
         {
@@ -132,7 +132,7 @@ public unsafe class DistanceLimit : Constraint
             ref DistanceLimitData data = ref handle.Data;
             ref RigidBodyData body2 = ref data.Body2.Data;
             JVector.Subtract(value, body2.Position, out data.LocalAnchor2);
-            JVector.TransposedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
+            JVector.ConjugatedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
         }
         get
         {

--- a/src/Jitter2/Dynamics/Constraints/FixedAngle.cs
+++ b/src/Jitter2/Dynamics/Constraints/FixedAngle.cs
@@ -81,8 +81,8 @@ public unsafe class FixedAngle : Constraint
         data.Softness = 0.001f;
         data.BiasFactor = 0.2f;
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         data.Q0 = q2.Conj() * q1;
     }
@@ -94,8 +94,8 @@ public unsafe class FixedAngle : Constraint
         ref RigidBodyData body1 = ref data.Body1.Data;
         ref RigidBodyData body2 = ref data.Body2.Data;
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         JQuaternion quat0 = data.Q0 * q1.Conj() * q2;
 

--- a/src/Jitter2/Dynamics/Constraints/HingeAngle.cs
+++ b/src/Jitter2/Dynamics/Constraints/HingeAngle.cs
@@ -96,8 +96,8 @@ public unsafe class HingeAngle : Constraint
 
         data.Axis = JVector.TransposedTransform(axis, body2.Orientation);
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         data.Q0 = q2.Conj() * q1;
     }
@@ -119,8 +119,8 @@ public unsafe class HingeAngle : Constraint
         ref RigidBodyData body1 = ref data.Body1.Data;
         ref RigidBodyData body2 = ref data.Body2.Data;
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         JVector p0 = MathHelper.CreateOrthonormal(data.Axis);
         JVector p1 = data.Axis % p0;
@@ -193,8 +193,8 @@ public unsafe class HingeAngle : Constraint
         get
         {
             ref HingeAngleData data = ref handle.Data;
-            JQuaternion q1 = JQuaternion.CreateFromMatrix(data.Body1.Data.Orientation);
-            JQuaternion q2 = JQuaternion.CreateFromMatrix(data.Body2.Data.Orientation);
+            JQuaternion q1 = data.Body1.Data.Orientation;
+            JQuaternion q2 = data.Body2.Data.Orientation;
 
             JQuaternion quat0 = data.Q0 * q1.Conj() * q2;
 

--- a/src/Jitter2/Dynamics/Constraints/LinearMotor.cs
+++ b/src/Jitter2/Dynamics/Constraints/LinearMotor.cs
@@ -94,8 +94,8 @@ public unsafe class LinearMotor : Constraint
         axis1.Normalize();
         axis2.Normalize();
 
-        JVector.TransposedTransform(axis1, body1.Orientation, out data.LocalAxis1);
-        JVector.TransposedTransform(axis2, body2.Orientation, out data.LocalAxis2);
+        JVector.ConjugatedTransform(axis1, body1.Orientation, out data.LocalAxis1);
+        JVector.ConjugatedTransform(axis2, body2.Orientation, out data.LocalAxis2);
 
         data.MaxForce = 0;
         data.Velocity = 0;

--- a/src/Jitter2/Dynamics/Constraints/PointOnLine.cs
+++ b/src/Jitter2/Dynamics/Constraints/PointOnLine.cs
@@ -104,10 +104,10 @@ public unsafe class PointOnLine : Constraint
         JVector.Subtract(anchor1, body1.Position, out data.LocalAnchor1);
         JVector.Subtract(anchor2, body2.Position, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
-        JVector.TransposedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
+        JVector.ConjugatedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
+        JVector.ConjugatedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(axis, body1.Orientation, out data.LocalAxis);
+        JVector.ConjugatedTransform(axis, body1.Orientation, out data.LocalAxis);
 
         data.BiasFactor = 0.01f;
         data.Softness = 0.00001f;

--- a/src/Jitter2/Dynamics/Constraints/PointOnPlane.cs
+++ b/src/Jitter2/Dynamics/Constraints/PointOnPlane.cs
@@ -102,10 +102,10 @@ public unsafe class PointOnPlane : Constraint
         JVector.Subtract(anchor1, body1.Position, out data.LocalAnchor1);
         JVector.Subtract(anchor2, body2.Position, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
-        JVector.TransposedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
+        JVector.ConjugatedTransform(data.LocalAnchor1, body1.Orientation, out data.LocalAnchor1);
+        JVector.ConjugatedTransform(data.LocalAnchor2, body2.Orientation, out data.LocalAnchor2);
 
-        JVector.TransposedTransform(axis, body1.Orientation, out data.LocalAxis);
+        JVector.ConjugatedTransform(axis, body1.Orientation, out data.LocalAxis);
 
         data.BiasFactor = 0.01f;
         data.Softness = 0.00001f;

--- a/src/Jitter2/Dynamics/Constraints/TwistAngle.cs
+++ b/src/Jitter2/Dynamics/Constraints/TwistAngle.cs
@@ -96,8 +96,8 @@ public unsafe class TwistAngle : Constraint
 
         data.B = JVector.TransposedTransform(axis2, body2.Orientation);
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         data.Q0 = q2.Conj() * q1;
     }
@@ -119,8 +119,8 @@ public unsafe class TwistAngle : Constraint
         ref RigidBodyData body1 = ref data.Body1.Data;
         ref RigidBodyData body2 = ref data.Body2.Data;
 
-        JQuaternion q1 = JQuaternion.CreateFromMatrix(body1.Orientation);
-        JQuaternion q2 = JQuaternion.CreateFromMatrix(body2.Orientation);
+        JQuaternion q1 = body1.Orientation;
+        JQuaternion q2 = body2.Orientation;
 
         JMatrix m = (-1.0f / 2.0f) * QMatrix.ProjectMultiplyLeftRight(data.Q0 * q1.Conj(), q2);
 
@@ -171,8 +171,8 @@ public unsafe class TwistAngle : Constraint
         get
         {
             ref var data = ref handle.Data;
-            JQuaternion q1 = JQuaternion.CreateFromMatrix(data.Body1.Data.Orientation);
-            JQuaternion q2 = JQuaternion.CreateFromMatrix(data.Body2.Data.Orientation);
+            JQuaternion q1 = data.Body1.Data.Orientation;
+            JQuaternion q2 = data.Body2.Data.Orientation;
 
             JQuaternion quat0 = data.Q0 * q1.Conj() * q2;
 

--- a/src/Jitter2/Dynamics/Contact.cs
+++ b/src/Jitter2/Dynamics/Contact.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Jitter2.LinearMath;
 using Jitter2.UnmanagedMemory;
 
@@ -416,8 +417,8 @@ public struct ContactData
 
             JVector.Subtract(point1, b1.Position, out RelativePos1);
             JVector.Subtract(point2, b2.Position, out RelativePos2);
-            JVector.TransposedTransform(RelativePos1, b1.Orientation, out RealRelPos1);
-            JVector.TransposedTransform(RelativePos2, b2.Orientation, out RealRelPos2);
+            JVector.ConjugatedTransform(RelativePos1, b1.Orientation, out RealRelPos1);
+            JVector.ConjugatedTransform(RelativePos2, b2.Orientation, out RealRelPos2);
 
             Penetration = penetration;
 

--- a/src/Jitter2/Dynamics/RigidBody.cs
+++ b/src/Jitter2/Dynamics/RigidBody.cs
@@ -46,7 +46,7 @@ public struct RigidBodyData
     public JVector DeltaVelocity;
     public JVector DeltaAngularVelocity;
 
-    public JMatrix Orientation;
+    public JQuaternion Orientation;
     public JMatrix InverseInertiaWorld;
 
     public float InverseMass;
@@ -143,7 +143,7 @@ public sealed class RigidBody : IListIndex, IDebugDrawable
 
         Shapes = new ReadOnlyList<Shape>(shapes);
 
-        Data.Orientation = JMatrix.Identity;
+        Data.Orientation = JQuaternion.Identity;
         SetDefaultMassInertia();
 
         RigidBodyId = World.RequestId();
@@ -238,7 +238,7 @@ public sealed class RigidBody : IListIndex, IDebugDrawable
         }
     }
 
-    public JMatrix Orientation
+    public JQuaternion Orientation
     {
         get => Data.Orientation;
         set
@@ -289,8 +289,9 @@ public sealed class RigidBody : IListIndex, IDebugDrawable
         }
         else
         {
-            JMatrix.Multiply(Data.Orientation, inverseInertia, out Data.InverseInertiaWorld);
-            JMatrix.MultiplyTransposed(Data.InverseInertiaWorld, Data.Orientation, out Data.InverseInertiaWorld);
+            var bodyOrientation = JMatrix.CreateFromQuaternion(Data.Orientation);
+            JMatrix.Multiply(bodyOrientation, inverseInertia, out Data.InverseInertiaWorld);
+            JMatrix.MultiplyTransposed(Data.InverseInertiaWorld, bodyOrientation, out Data.InverseInertiaWorld);
             Data.InverseMass = inverseMass;
         }
     }

--- a/src/Jitter2/LinearMath/JMatrix.cs
+++ b/src/Jitter2/LinearMath/JMatrix.cs
@@ -71,6 +71,7 @@ public struct JMatrix
         M33 = m33;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix FromColumns(in JVector col1, in JVector col2, in JVector col3)
     {
         Unsafe.SkipInit(out JMatrix res);
@@ -80,12 +81,14 @@ public struct JMatrix
         return res;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe ref JVector UnsafeGet(int index)
     {
         JVector* ptr = (JVector*)Unsafe.AsPointer(ref this);
         return ref ptr[index];
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe JVector GetColumn(int index)
     {
         fixed (float* ptr = &M11)
@@ -95,18 +98,21 @@ public struct JMatrix
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix Multiply(in JMatrix matrix1, in JMatrix matrix2)
     {
         Multiply(matrix1, matrix2, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix MultiplyTransposed(in JMatrix matrix1, in JMatrix matrix2)
     {
         MultiplyTransposed(matrix1, matrix2, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix TransposedMultiply(in JMatrix matrix1, in JMatrix matrix2)
     {
         TransposedMultiply(matrix1, matrix2, out JMatrix result);
@@ -147,6 +153,7 @@ public struct JMatrix
         result.M33 = num8;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix Add(JMatrix matrix1, JMatrix matrix2)
     {
         Add(matrix1, matrix2, out JMatrix result);
@@ -288,6 +295,7 @@ public struct JMatrix
         result.M33 = num8;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Add(in JMatrix matrix1, in JMatrix matrix2, out JMatrix result)
     {
         result.M11 = matrix1.M11 + matrix2.M11;
@@ -301,6 +309,7 @@ public struct JMatrix
         result.M33 = matrix1.M33 + matrix2.M33;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Subtract(in JMatrix matrix1, in JMatrix matrix2, out JMatrix result)
     {
         result.M11 = matrix1.M11 - matrix2.M11;
@@ -314,12 +323,14 @@ public struct JMatrix
         result.M33 = matrix1.M33 - matrix2.M33;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly float Determinant()
     {
         return M11 * M22 * M33 + M12 * M23 * M31 + M13 * M21 * M32 -
                M31 * M22 * M13 - M32 * M23 * M11 - M33 * M21 * M12;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Inverse(in JMatrix matrix, out JMatrix result)
     {
         float det = matrix.Determinant();
@@ -357,12 +368,14 @@ public struct JMatrix
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix Multiply(JMatrix matrix1, float scaleFactor)
     {
         Multiply(in matrix1, scaleFactor, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Multiply(in JMatrix matrix1, float scaleFactor, out JMatrix result)
     {
         float num = scaleFactor;
@@ -377,12 +390,14 @@ public struct JMatrix
         result.M33 = matrix1.M33 * num;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix CreateFromQuaternion(JQuaternion quaternion)
     {
         CreateFromQuaternion(quaternion, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Absolute(in JMatrix matrix, out JMatrix result)
     {
         result.M11 = Math.Abs(matrix.M11);
@@ -396,6 +411,7 @@ public struct JMatrix
         result.M33 = Math.Abs(matrix.M33);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void CreateFromQuaternion(in JQuaternion quaternion, out JMatrix result)
     {
         float r = quaternion.W;
@@ -414,6 +430,7 @@ public struct JMatrix
         result.M33 = 1.0f - 2.0f * (i * i + j * j);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix Transpose(in JMatrix matrix)
     {
         Transpose(in matrix, out JMatrix result);
@@ -423,11 +440,13 @@ public struct JMatrix
     /// <summary>
     /// Returns JMatrix(0, -vec.Z, vec.Y, vec.Z, 0, -vec.X, -vec.Y, vec.X, 0)-
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix CreateCrossProduct(in JVector vec)
     {
         return new JMatrix(0, -vec.Z, vec.Y, vec.Z, 0, -vec.X, -vec.Y, vec.X, 0);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void Transpose(in JMatrix matrix, out JMatrix result)
     {
         result.M11 = matrix.M11;
@@ -441,6 +460,7 @@ public struct JMatrix
         result.M33 = matrix.M33;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix operator *(in JMatrix matrix1, in JMatrix matrix2)
     {
         JMatrix result;
@@ -456,29 +476,34 @@ public struct JMatrix
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public float Trace()
     {
         return M11 + M22 + M33;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix operator *(float factor, in JMatrix matrix)
     {
         Multiply(matrix, factor, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix operator *(in JMatrix matrix, float factor)
     {
         Multiply(matrix, factor, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix operator +(in JMatrix value1, in JMatrix value2)
     {
         Add(value1, value2, out JMatrix result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix operator -(in JMatrix value1, in JMatrix value2)
     {
         Subtract(value1, value2, out JMatrix result);

--- a/src/Jitter2/LinearMath/JVector.cs
+++ b/src/Jitter2/LinearMath/JVector.cs
@@ -82,6 +82,7 @@ public struct JVector
         Z = xyz;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public unsafe ref float UnsafeGet(int index)
     {
         float* ptr = (float*)Unsafe.AsPointer(ref this);
@@ -105,7 +106,6 @@ public struct JVector
             }
         }
     }
-
     public readonly override string ToString()
     {
         return $"{X:F6} {Y:F6} {Z:F6}";
@@ -134,12 +134,14 @@ public struct JVector
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Min(in JVector value1, in JVector value2)
     {
         Min(value1, value2, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Min(in JVector value1, in JVector value2, out JVector result)
     {
         result.X = value1.X < value2.X ? value1.X : value2.X;
@@ -147,23 +149,28 @@ public struct JVector
         result.Z = value1.Z < value2.Z ? value1.Z : value2.Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Max(in JVector value1, in JVector value2)
     {
         Max(value1, value2, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Abs(in JVector value1)
     {
         return new JVector(MathF.Abs(value1.X), MathF.Abs(value1.Y), MathF.Abs(value1.Z));
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float MaxAbs(in JVector value1)
     {
         JVector abs = Abs(value1);
         return MathF.Max(MathF.Max(abs.X, abs.Y), abs.Z);
+    
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Max(in JVector value1, in JVector value2, out JVector result)
     {
         result.X = value1.X > value2.X ? value1.X : value2.X;
@@ -171,6 +178,7 @@ public struct JVector
         result.Z = value1.Z > value2.Z ? value1.Z : value2.Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void MakeZero()
     {
         X = 0.0f;
@@ -181,18 +189,34 @@ public struct JVector
     /// <summary>
     /// Calculates matrix \times vector, where vector is a column vector.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Transform(in JVector vector, in JMatrix matrix)
     {
         Transform(vector, matrix, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JVector Transform(in JVector vector, in JQuaternion quat)
+    {
+        Transform(vector, quat, out JVector result);
+        return result;
+    }
+
     /// <summary>
     /// Calculates matrix^\mathrf{T} \times vector, where vector is a column vector.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector TransposedTransform(in JVector vector, in JMatrix matrix)
     {
         TransposedTransform(vector, matrix, out JVector result);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JVector TransposedTransform(in JVector vector, in JQuaternion quat)
+    {
+        ConjugatedTransform(vector, quat, out JVector result);
         return result;
     }
 
@@ -227,8 +251,57 @@ public struct JVector
     }
 
     /// <summary>
+    /// Transforms the vector by a quaternion.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Transform(in JVector vector, in JQuaternion quaternion, out JVector result)
+    {
+        float x = vector.X;
+        float y = vector.Y;
+        float z = vector.Z;
+        float qx = quaternion.X;
+        float qy = quaternion.Y;
+        float qz = quaternion.Z;
+        float qw = quaternion.W;
+
+        float num0 = qw * x + qy * z - qz * y;
+        float num1 = qw * y + qz * x - qx * z;
+        float num2 = qw * z + qx * y - qy * x;
+        float num3 = -qx * x - qy * y - qz * z;
+
+        result.X = num0 * qw - num3 * qx - num1 * qz + num2 * qy;
+        result.Y = num1 * qw - num3 * qy - num2 * qx + num0 * qz;
+        result.Z = num2 * qw - num3 * qz - num0 * qy + num1 * qx;
+    }
+
+    /// <summary>
+    /// Transforms the vector by a conjugated quaternion.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ConjugatedTransform(in JVector vector, in JQuaternion quaternion, out JVector result)
+    {
+        float x = vector.X;
+        float y = vector.Y;
+        float z = vector.Z;
+        float qx = quaternion.X;
+        float qy = quaternion.Y;
+        float qz = quaternion.Z;
+        float qw = quaternion.W;
+
+        float num0 = qw * x - qy * z + qz * y;
+        float num1 = qw * y - qz * x + qx * z;
+        float num2 = qw * z - qx * y + qy * x;
+        float num3 = qx * x + qy * y + qz * z;
+
+        result.X = num0 * qw + num3 * qx + num1 * qz - num2 * qy;
+        result.Y = num1 * qw + num3 * qy + num2 * qx - num0 * qz;
+        result.Z = num2 * qw + num3 * qz + num0 * qy - num1 * qx;
+    }
+
+    /// <summary>
     /// Calculates the outer product.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JMatrix Outer(in JVector u, in JVector v)
     {
         JMatrix result;
@@ -250,6 +323,7 @@ public struct JVector
         return vector1.X * vector2.X + vector1.Y * vector2.Y + vector1.Z * vector2.Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Add(in JVector value1, in JVector value2)
     {
         Add(value1, value2, out JVector result);
@@ -264,6 +338,7 @@ public struct JVector
         result.Z = value1.Z + value2.Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Subtract(JVector value1, JVector value2)
     {
         Subtract(value1, value2, out JVector result);
@@ -282,12 +357,14 @@ public struct JVector
         result.Z = num2;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Cross(in JVector vector1, in JVector vector2)
     {
         Cross(vector1, vector2, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Cross(in JVector vector1, in JVector vector2, out JVector result)
     {
         float num0 = vector1.Y * vector2.Z - vector1.Z * vector2.Y;
@@ -299,11 +376,13 @@ public struct JVector
         result.Z = num2;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly override int GetHashCode()
     {
         return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Negate()
     {
         X = -X;
@@ -311,12 +390,14 @@ public struct JVector
         Z = -Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Negate(in JVector value)
     {
         Negate(value, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Negate(in JVector value, out JVector result)
     {
         float num0 = -value.X;
@@ -328,12 +409,14 @@ public struct JVector
         result.Z = num2;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Normalize(in JVector value)
     {
         Normalize(value, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Normalize()
     {
         float num2 = X * X + Y * Y + Z * Z;
@@ -343,6 +426,7 @@ public struct JVector
         Z *= num;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Normalize(in JVector value, out JVector result)
     {
         float num2 = value.X * value.X + value.Y * value.Y + value.Z * value.Z;
@@ -352,27 +436,32 @@ public struct JVector
         result.Z = value.Z * num;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly float LengthSquared()
     {
         return X * X + Y * Y + Z * Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly float Length()
     {
         return MathF.Sqrt(X * X + Y * Y + Z * Z);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Swap(ref JVector vector1, ref JVector vector2)
     {
         (vector2, vector1) = (vector1, vector2);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector Multiply(in JVector value1, float scaleFactor)
     {
         Multiply(value1, scaleFactor, out JVector result);
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Multiply(float factor)
     {
         X *= factor;
@@ -380,6 +469,7 @@ public struct JVector
         Z *= factor;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Multiply(in JVector value1, float scaleFactor, out JVector result)
     {
         result.X = value1.X * scaleFactor;
@@ -390,6 +480,7 @@ public struct JVector
     /// <summary>
     /// Calculates the cross product.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator %(in JVector vector1, in JVector vector2)
     {
         JVector result;
@@ -399,11 +490,13 @@ public struct JVector
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static float operator *(in JVector vector1, in JVector vector2)
     {
         return vector1.X * vector2.X + vector1.Y * vector2.Y + vector1.Z * vector2.Z;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator *(in JVector value1, float value2)
     {
         JVector result;
@@ -413,6 +506,7 @@ public struct JVector
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator *(float value1, in JVector value2)
     {
         JVector result;
@@ -422,6 +516,7 @@ public struct JVector
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator -(in JVector value1, in JVector value2)
     {
         JVector result;
@@ -431,11 +526,13 @@ public struct JVector
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator -(JVector left)
     {
         return Multiply(left, -1.0f);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static JVector operator +(in JVector value1, in JVector value2)
     {
         JVector result;

--- a/src/Jitter2/SoftBodies/BroadPhaseCollisionFilter.cs
+++ b/src/Jitter2/SoftBodies/BroadPhaseCollisionFilter.cs
@@ -46,7 +46,7 @@ public class BroadPhaseCollisionFilter : IBroadPhaseFilter
         if (i1 != null && i2 != null)
         {
             bool colliding = NarrowPhase.MPREPA(shapeA, shapeB,
-                JMatrix.Identity, JVector.Zero,
+                JQuaternion.Identity, JVector.Zero,
                 out JVector pA, out JVector pB, out JVector normal, out float penetration);
 
             if (!colliding) return false;

--- a/src/Jitter2/World.Detect.cs
+++ b/src/Jitter2/World.Detect.cs
@@ -368,7 +368,7 @@ public partial class World
         {
             static void Support(Shape shape, in JVector direction, out JVector v)
             {
-                JVector.TransposedTransform(direction, shape.RigidBody!.Data.Orientation, out JVector tmp);
+                JVector.ConjugatedTransform(direction, shape.RigidBody!.Data.Orientation, out JVector tmp);
                 shape.SupportMap(tmp, out v);
                 JVector.Transform(v, shape.RigidBody.Data.Orientation, out v);
                 JVector.Add(v, shape.RigidBody.Data.Position, out v);

--- a/src/Jitter2/World.Step.cs
+++ b/src/Jitter2/World.Step.cs
@@ -290,8 +290,10 @@ public partial class World
                 body.Force = JVector.Zero;
                 body.Torque = JVector.Zero;
 
-                JMatrix.Multiply(rigidBody.Orientation, body.inverseInertia, out rigidBody.InverseInertiaWorld);
-                JMatrix.MultiplyTransposed(rigidBody.InverseInertiaWorld, rigidBody.Orientation, out rigidBody.InverseInertiaWorld);
+                var bodyOrientation = JMatrix.CreateFromQuaternion(rigidBody.Orientation);
+
+                JMatrix.Multiply(bodyOrientation, body.inverseInertia, out rigidBody.InverseInertiaWorld);
+                JMatrix.MultiplyTransposed(rigidBody.InverseInertiaWorld, bodyOrientation, out rigidBody.InverseInertiaWorld);
 
                 rigidBody.InverseMass = body.inverseMass;
             }
@@ -657,12 +659,14 @@ public partial class World
             }
 
             JQuaternion dorn = new(axis.X, axis.Y, axis.Z, (float)Math.Cos(angle * substep_dt * 0.5f));
-            JQuaternion.CreateFromMatrix(rigidBody.Orientation, out JQuaternion ornA);
+            //JQuaternion.CreateFromMatrix(rigidBody.Orientation, out JQuaternion ornA);
+            JQuaternion ornA = rigidBody.Orientation;
 
             JQuaternion.Multiply(dorn, ornA, out dorn);
 
             dorn.Normalize();
-            JMatrix.CreateFromQuaternion(dorn, out rigidBody.Orientation);
+            //JMatrix.CreateFromQuaternion(dorn, out rigidBody.Orientation);
+            rigidBody.Orientation = dorn;
         }
     }
 

--- a/src/JitterDemo/Conversion.cs
+++ b/src/JitterDemo/Conversion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using Jitter2.Dynamics;
 using Jitter2.LinearMath;
@@ -7,24 +8,6 @@ namespace JitterDemo;
 
 public class Conversion
 {
-    public static JMatrix ToJitterMatrix(Matrix4 im)
-    {
-        JMatrix mat;
-        mat.M11 = im.M11;
-        mat.M12 = im.M12;
-        mat.M13 = im.M13;
-
-        mat.M21 = im.M21;
-        mat.M22 = im.M22;
-        mat.M23 = im.M23;
-
-        mat.M31 = im.M31;
-        mat.M32 = im.M32;
-        mat.M33 = im.M33;
-
-        return mat;
-    }
-
     public static JVector ToJitterVector(Vector3 im)
     {
         return new JVector(im.X, im.Y, im.Z);
@@ -37,43 +20,35 @@ public class Conversion
 
     public static Matrix4 FromJitter(JMatrix jmat)
     {
-        Matrix4 mat = new Matrix4();
-        mat.M11 = jmat.M11;
-        mat.M12 = jmat.M12;
-        mat.M13 = jmat.M13;
-        mat.M14 = 0;
+        return new Matrix4
+        {
+            M11 = jmat.M11,
+            M12 = jmat.M12,
+            M13 = jmat.M13,
+            M14 = 0,
 
-        mat.M21 = jmat.M21;
-        mat.M22 = jmat.M22;
-        mat.M23 = jmat.M23;
-        mat.M24 = 0;
+            M21 = jmat.M21,
+            M22 = jmat.M22,
+            M23 = jmat.M23,
+            M24 = 0,
 
-        mat.M31 = jmat.M31;
-        mat.M32 = jmat.M32;
-        mat.M33 = jmat.M33;
-        mat.M34 = 0;
+            M31 = jmat.M31,
+            M32 = jmat.M32,
+            M33 = jmat.M33,
+            M34 = 0,
 
-        mat.M41 = 0;
-        mat.M42 = 0;
-        mat.M43 = 0;
-        mat.M44 = 1;
-
-        return mat;
-    }
-
-    public static unsafe void FromJitterOpt(RigidBody body, ref Matrix4 mat)
-    {
-        Unsafe.CopyBlock(Unsafe.AsPointer(ref mat.M11), Unsafe.AsPointer(ref body.Data.Orientation.M11), 12);
-        Unsafe.CopyBlock(Unsafe.AsPointer(ref mat.M12), Unsafe.AsPointer(ref body.Data.Orientation.M12), 12);
-        Unsafe.CopyBlock(Unsafe.AsPointer(ref mat.M13), Unsafe.AsPointer(ref body.Data.Orientation.M13), 12);
-        Unsafe.CopyBlock(Unsafe.AsPointer(ref mat.M14), Unsafe.AsPointer(ref body.Data.Position.X), 12);
+            M41 = 0,
+            M42 = 0,
+            M43 = 0,
+            M44 = 1
+        };
     }
 
     public static Matrix4 FromJitter(RigidBody body)
     {
         Unsafe.SkipInit(out Matrix4 mat);
 
-        ref JMatrix ori = ref body.Data.Orientation;
+        JMatrix ori = JMatrix.CreateFromQuaternion(body.Data.Orientation);
         ref JVector pos = ref body.Data.Position;
 
         mat.M11 = ori.M11;

--- a/src/JitterDemo/Demos/Car/Wheel.cs
+++ b/src/JitterDemo/Demos/Car/Wheel.cs
@@ -218,7 +218,9 @@ public class Wheel
         JVector worldPos = car.Position + JVector.Transform(Position, car.Orientation);
         JVector worldAxis = JVector.Transform(Up, car.Orientation);
 
-        JVector forward = -car.Orientation.GetColumn(2);
+
+
+        JVector forward = JVector.Transform(-JVector.UnitZ, car.Orientation); //-car.Orientation.GetColumn(2);
         JVector wheelFwd = JVector.Transform(forward, JMatrix.CreateRotationMatrix(worldAxis, SteerAngle));
 
         JVector wheelLeft = JVector.Cross(worldAxis, wheelFwd);

--- a/src/JitterDemo/Demos/Common.cs
+++ b/src/JitterDemo/Demos/Common.cs
@@ -96,10 +96,10 @@ public static class Common
         parts[(int)RagdollParts.LowerLegLeft].Position = new JVector(0.11f, -1.2f, 0);
         parts[(int)RagdollParts.LowerLegRight].Position = new JVector(-0.11f, -1.2f, 0);
 
-        parts[(int)RagdollParts.UpperArmLeft].Orientation = JMatrix.CreateRotationZ(MathF.PI / 2.0f);
-        parts[(int)RagdollParts.UpperArmRight].Orientation = JMatrix.CreateRotationZ(MathF.PI / 2.0f);
-        parts[(int)RagdollParts.LowerArmLeft].Orientation = JMatrix.CreateRotationZ(MathF.PI / 2.0f);
-        parts[(int)RagdollParts.LowerArmRight].Orientation = JMatrix.CreateRotationZ(MathF.PI / 2.0f);
+        parts[(int)RagdollParts.UpperArmLeft].Orientation = JQuaternion.CreateRotationZ(MathF.PI / 2.0f);
+        parts[(int)RagdollParts.UpperArmRight].Orientation = JQuaternion.CreateRotationZ(MathF.PI / 2.0f);
+        parts[(int)RagdollParts.LowerArmLeft].Orientation = JQuaternion.CreateRotationZ(MathF.PI / 2.0f);
+        parts[(int)RagdollParts.LowerArmRight].Orientation = JQuaternion.CreateRotationZ(MathF.PI / 2.0f);
 
         parts[(int)RagdollParts.UpperArmLeft].Position = new JVector(0.30f, -0.2f, 0);
         parts[(int)RagdollParts.UpperArmRight].Position = new JVector(-0.30f, -0.2f, 0);
@@ -217,14 +217,14 @@ public static class Common
         }
     }
 
-    public static void BuildTower(Vector3 pos, int height = 40, Action<RigidBody>? action = null)
+    public static void BuildTower(JVector pos, int height = 40, Action<RigidBody>? action = null)
     {
         Playground pg = (Playground)RenderWindow.Instance;
         World world = pg.World;
 
-        Matrix4 halfRotationStep = MatrixHelper.CreateRotationY(MathF.PI * 2.0f / 64.0f);
-        Matrix4 fullRotationStep = halfRotationStep * halfRotationStep;
-        Matrix4 orientation = Matrix4.Identity;
+        JQuaternion halfRotationStep = JQuaternion.CreateRotationY(MathF.PI * 2.0f / 64.0f);
+        JQuaternion fullRotationStep = halfRotationStep * halfRotationStep;
+        JQuaternion orientation = JQuaternion.Identity;
 
         for (int e = 0; e < height; e++)
         {
@@ -232,13 +232,13 @@ public static class Common
 
             for (int i = 0; i < 32; i++)
             {
-                Vector3 position = pos + Vector3.Transform(
-                    new Vector3(0, 0.5f + e, 19.5f), orientation);
+                JVector position = pos + JVector.Transform(
+                    new JVector(0, 0.5f + e, 19.5f), orientation);
 
                 Shape shape = new BoxShape(3f, 1, 0.2f);
                 var body = world.CreateRigidBody();
 
-                body.Orientation = Conversion.ToJitterMatrix(orientation);
+                body.Orientation = orientation;
                 body.Position = new JVector(position.X, position.Y, position.Z);
 
                 body.AddShape(shape);

--- a/src/JitterDemo/Demos/Demo01.cs
+++ b/src/JitterDemo/Demos/Demo01.cs
@@ -66,7 +66,7 @@ public class Demo01 : IDemo
         {
             // Add a car made out of constraints
             JVector carPos = new JVector(10, 9, -20);
-            JMatrix rot = JMatrix.CreateRotationY(MathF.PI / 2.0f);
+            JQuaternion rot = JQuaternion.CreateRotationY(MathF.PI / 2.0f);
 
             car.BuildCar(world, carPos, body =>
                 {

--- a/src/JitterDemo/Demos/Demo02.cs
+++ b/src/JitterDemo/Demos/Demo02.cs
@@ -1,4 +1,5 @@
 using Jitter2;
+using Jitter2.LinearMath;
 using JitterDemo.Renderer;
 using JitterDemo.Renderer.OpenGL;
 
@@ -15,7 +16,7 @@ public class Demo02 : IDemo
 
         pg.ResetScene();
 
-        Common.BuildTower(Vector3.Zero);
+        Common.BuildTower(JVector.Zero);
 
         world.SolverIterations = 18;
     }

--- a/src/JitterDemo/Demos/Demo17.cs
+++ b/src/JitterDemo/Demos/Demo17.cs
@@ -66,12 +66,12 @@ public class Demo17 : IDemo, ICleanDemo
         var b0 = world.CreateRigidBody();
         b0.Position = new JVector(-1, 10, 0);
         b0.AddShape(new BoxShape(1));
-        b0.Orientation = JMatrix.CreateRotationX(0.4f);
+        b0.Orientation = JQuaternion.CreateRotationX(0.4f);
 
         var b1 = world.CreateRigidBody();
         b1.Position = new JVector(0, 10, 0);
         b1.AddShape(new CapsuleShape(0.4f));
-        b1.Orientation = JMatrix.CreateRotationX(1f);
+        b1.Orientation = JQuaternion.CreateRotationX(1f);
 
         var b2 = world.CreateRigidBody();
         b2.Position = new JVector(1, 11, 0);

--- a/src/JitterDemo/Demos/Voxels/VoxelShape.cs
+++ b/src/JitterDemo/Demos/Voxels/VoxelShape.cs
@@ -31,13 +31,11 @@ public class VoxelShape : Shape
         result += Position;
     }
 
-    public override void CalculateBoundingBox(in JMatrix orientation, in JVector position, out JBBox box)
+    public override void CalculateBoundingBox(in JQuaternion orientation, in JVector position, out JBBox box)
     {
         // NOTE: We do not support any transformation of the body here.
-        System.Diagnostics.Debug.Assert(MathHelper.CloseToZero(orientation.GetColumn(0) - JVector.UnitX));
-        System.Diagnostics.Debug.Assert(MathHelper.CloseToZero(orientation.GetColumn(1) - JVector.UnitY));
-        System.Diagnostics.Debug.Assert(MathHelper.CloseToZero(orientation.GetColumn(2) - JVector.UnitZ));
-        System.Diagnostics.Debug.Assert(MathHelper.CloseToZero(position));
+        System.Diagnostics.Debug.Assert(orientation.W > 0.999f, "Voxel shape can not be attached to a transformed body.");
+        System.Diagnostics.Debug.Assert(MathHelper.CloseToZero(position), "Voxel shape can not be attached to a transformed body.");
 
         box.Min = Position - JVector.One * 0.5f;
         box.Max = Position + JVector.One * 0.5f;

--- a/src/JitterDemo/Playground.cs
+++ b/src/JitterDemo/Playground.cs
@@ -173,7 +173,7 @@ public partial class Playground : RenderWindow
         {
             if (body.Tag is RigidBodyTag { DoNotDraw: true }) continue;
 
-            Conversion.FromJitterOpt(body, ref mat);
+            mat = Conversion.FromJitter(body);
 
             foreach (Shape shape in body.Shapes)
             {

--- a/src/JitterDemo/Program.cs
+++ b/src/JitterDemo/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Jitter2.Dynamics;
 using JitterDemo.Renderer.OpenGL;
 
 namespace JitterDemo;

--- a/src/JitterTests/CollisionTests.cs
+++ b/src/JitterTests/CollisionTests.cs
@@ -26,7 +26,7 @@ public class CollisionTests
 
         SphereShape s1 = new(radius);
 
-        bool hit = NarrowPhase.RayCast(s1, JMatrix.CreateRotationX(0.32f), sp,
+        bool hit = NarrowPhase.RayCast(s1, JQuaternion.CreateRotationX(0.32f), sp,
             op, sp - op, out float fraction, out JVector normal);
 
         JVector cn = JVector.Normalize(op - sp); // analytical normal
@@ -34,7 +34,9 @@ public class CollisionTests
 
         Assert.That(hit);
         Assert.That(MathHelper.CloseToZero(normal - cn, 1e-6f));
-        Assert.That(MathF.Abs((hp - sp).Length() - radius) < 1e-6f);
+        
+        float distance = (hp - sp).Length();
+        Assert.That(MathF.Abs(distance - radius) < 1e-4f);
     }
 
     [TestCase]
@@ -43,7 +45,7 @@ public class CollisionTests
         var s1 = new SphereShape(0.5f);
         var s2 = new BoxShape(1);
 
-        var rot = JMatrix.CreateRotationZ(MathF.PI / 4.0f);
+        var rot = JQuaternion.CreateRotationZ(MathF.PI / 4.0f);
         var sweep = JVector.Normalize(new JVector(1, 1, 0));
 
         bool hit = NarrowPhase.SweepTest(s1, s2, rot, rot,
@@ -71,7 +73,7 @@ public class CollisionTests
 
         // -----------------------------------------------
 
-        NarrowPhase.MPREPA(s1, s2, JMatrix.Identity, JMatrix.Identity, new JVector(-0.25f, 0, 0), new JVector(+0.25f, 0, 0),
+        NarrowPhase.MPREPA(s1, s2, JQuaternion.Identity, JQuaternion.Identity, new JVector(-0.25f, 0, 0), new JVector(+0.25f, 0, 0),
             out JVector pointA, out JVector pointB, out JVector normal, out float penetration);
 
         // pointA is on s1 and pointB is on s2
@@ -86,7 +88,7 @@ public class CollisionTests
 
         // -----------------------------------------------
 
-        NarrowPhase.GJKEPA(s1, s2, JMatrix.Identity, JMatrix.Identity, new JVector(-0.25f, 0, 0), new JVector(+0.25f, 0, 0),
+        NarrowPhase.GJKEPA(s1, s2, JQuaternion.Identity, JQuaternion.Identity, new JVector(-0.25f, 0, 0), new JVector(+0.25f, 0, 0),
             out pointA, out pointB, out normal, out penetration);
 
         // pointA is on s1 and pointB is on s2
@@ -104,7 +106,7 @@ public class CollisionTests
         BoxShape b1 = new(1);
         BoxShape b2 = new(1);
 
-        NarrowPhase.MPREPA(b1, b2, JMatrix.Identity, JMatrix.Identity, new JVector(-0.25f, 0.1f, 0), new JVector(+0.25f, -0.1f, 0),
+        NarrowPhase.MPREPA(b1, b2, JQuaternion.Identity, JQuaternion.Identity, new JVector(-0.25f, 0.1f, 0), new JVector(+0.25f, -0.1f, 0),
             out pointA, out pointB, out normal, out penetration);
 
         // pointA is on s1 and pointB is on s2
@@ -119,7 +121,7 @@ public class CollisionTests
 
         // -----------------------------------------------
 
-        NarrowPhase.GJKEPA(b1, b2, JMatrix.Identity, JMatrix.Identity, new JVector(-2.25f, 0, 0), new JVector(+2.25f, 0, 0),
+        NarrowPhase.GJKEPA(b1, b2, JQuaternion.Identity, JQuaternion.Identity, new JVector(-2.25f, 0, 0), new JVector(+2.25f, 0, 0),
             out pointA, out pointB, out normal, out penetration);
 
         // the collision normal points from s2 to s1

--- a/src/JitterTests/Helper.cs
+++ b/src/JitterTests/Helper.cs
@@ -11,9 +11,9 @@ public static class Helper
 
     public static RigidBody BuildTower(World world, JVector pos, int size = 40)
     {
-        JMatrix halfRotationStep = JMatrix.CreateRotationY(MathF.PI * 2.0f / 64.0f);
-        JMatrix fullRotationStep = halfRotationStep * halfRotationStep;
-        JMatrix orientation = JMatrix.Identity;
+        JQuaternion halfRotationStep = JQuaternion.CreateRotationY(MathF.PI * 2.0f / 64.0f);
+        JQuaternion fullRotationStep = halfRotationStep * halfRotationStep;
+        JQuaternion orientation = JQuaternion.Identity;
 
         RigidBody last = null!;
 


### PR DESCRIPTION
Big and breaking change. Switch orientation to JQuaternion (4x1) from JMatrix (3x3). JMatrices still represent affine transformations and the inertia tensor.