### PR TITLE
Improve stepper logic

### DIFF
--- a/src/Jitter2/World.Step.cs
+++ b/src/Jitter2/World.Step.cs
@@ -224,7 +224,7 @@ public partial class World
 
         for (int i = 0; i < phs.Slots.Length / divisions; i++)
         {
-            int t = i * stepper % phs.Slots.Length;
+            int t = (int)((i * divisions + stepper) % phs.Slots.Length);
 
             var n = phs.Slots[t];
             if (n.ID == 0) continue;

--- a/src/Jitter2/World.Step.cs
+++ b/src/Jitter2/World.Step.cs
@@ -58,7 +58,7 @@ public partial class World
     private Action<Parallel.Batch> updateShapes;
     private Action<Parallel.Batch> detectCollisions;
 
-    private int stepper;
+    private uint stepper;
 
     private void InitParallelCallbacks()
     {


### PR DESCRIPTION
1. make stepper uint to avoid OutofRangeException
2. replace the original iteration on potential pairs, which has less chance to visit prime number index , and more chance on zero.