### PR TITLE
Added SimplexSolver

### DIFF
--- a/src/Jitter2/Collision/NarrowPhase/ConvexPolytope.cs
+++ b/src/Jitter2/Collision/NarrowPhase/ConvexPolytope.cs
@@ -27,6 +27,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Jitter2.LinearMath;
 using Jitter2.UnmanagedMemory;
+using Vertex = Jitter2.Collision.MinkowskiDifference.Vertex;
 
 namespace Jitter2.Collision;
 
@@ -50,25 +51,6 @@ public unsafe struct ConvexPolytope
 
         public float NormalSq;
         public float ClosestToOriginSq;
-    }
-
-    /// <summary>
-    /// Represents a vertex utilized in algorithms that operate on the Minkowski sum of two shapes.
-    /// </summary>
-    public struct Vertex
-    {
-        public JVector V;
-        public JVector A;
-        public JVector B;
-
-        public Vertex(JVector v)
-        {
-#if NET6_0
-            A = new JVector();
-            B = new JVector();
-#endif
-            V = v;
-        }
     }
 
     private struct Edge
@@ -358,23 +340,9 @@ public unsafe struct ConvexPolytope
     /// </summary>
     public void InitHeap()
     {
-        if (vertices == (void*)0)
-        {
-            vertices = MemoryHelper.AllocateHeap<Vertex>(MaxVertices);
-            triangles = MemoryHelper.AllocateHeap<Triangle>(MaxTriangles);
-        }
-    }
-
-    /// <summary>
-    /// Incorporates a single point into the polyhedron, disregarding A- and B-space.
-    /// This operation contrasts with <see cref="AddVertex"/>.
-    /// </summary>
-    /// <returns>Indicates whether the polyhedron successfully incorporated the new point.</returns>
-    public bool AddPoint(in JVector point)
-    {
-        Unsafe.SkipInit(out Vertex v);
-        v.V = point;
-        return AddVertex(v);
+        if (vertices != (void*)0) return;
+        vertices = MemoryHelper.AllocateHeap<Vertex>(MaxVertices);
+        triangles = MemoryHelper.AllocateHeap<Triangle>(MaxTriangles);
     }
 
     /// <summary>

--- a/src/Jitter2/Collision/NarrowPhase/MinkowskiDifference.cs
+++ b/src/Jitter2/Collision/NarrowPhase/MinkowskiDifference.cs
@@ -33,6 +33,25 @@ namespace Jitter2.Collision;
 /// </summary>
 public struct MinkowskiDifference
 {
+    /// <summary>
+    /// Represents a vertex utilized in algorithms that operate on the Minkowski sum of two shapes.
+    /// </summary>
+    public struct Vertex
+    {
+        public JVector V;
+        public JVector A;
+        public JVector B;
+
+        public Vertex(JVector v)
+        {
+#if NET6_0
+            A = new JVector();
+            B = new JVector();
+#endif
+            V = v;
+        }
+    }
+
     public ISupportMappable SupportA, SupportB;
     public JQuaternion OrientationB;
     public JVector PositionB;
@@ -50,7 +69,7 @@ public struct MinkowskiDifference
     /// Calculates the support function S_{A-B}(d) = S_{A}(d) - S_{B}(-d), where "d" represents the direction.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly void Support(in JVector direction, out ConvexPolytope.Vertex v)
+    public readonly void Support(in JVector direction, out Vertex v)
     {
         JVector.Negate(direction, out JVector tmp);
         SupportA.SupportMap(direction, out v.A);
@@ -62,7 +81,7 @@ public struct MinkowskiDifference
     /// Retrieves a point within the Minkowski Difference.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly void GetCenter(out ConvexPolytope.Vertex center)
+    public readonly void GetCenter(out Vertex center)
     {
         SupportA.GetCenter(out center.A);
         SupportB.GetCenter(out center.B);

--- a/src/Jitter2/Collision/NarrowPhase/SimplexSolver.cs
+++ b/src/Jitter2/Collision/NarrowPhase/SimplexSolver.cs
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) Thorben Linneweber and others
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+using System;
+using System.Runtime.CompilerServices;
+using Jitter2.LinearMath;
+
+namespace Jitter2.Collision;
+
+// This is a GJK-Implementation "by the book".
+
+public unsafe struct SimplexSolver
+{
+    private JVector v0;
+    private JVector v1;
+    private JVector v2;
+    private JVector v3;
+
+    private short useCount;
+
+    public void Reset()
+    {
+        useCount = 0;
+    }
+
+    public JVector ClosestSegment(int i0, int i1, out uint mask)
+    {
+        var ptr = (JVector*)Unsafe.AsPointer(ref this.v0);
+        JVector a = ptr[i0];
+        JVector b = ptr[i1];
+
+        // Compute vector v = b - a (the direction vector of the segment)
+
+        JVector v = b - a;
+
+        // Compute vector w = p - a (the vector from a to the point p)
+        JVector w = JVector.Zero - a;
+
+        // Project w onto v using dot products
+        float t = JVector.Dot(w, v) / JVector.Dot(v, v);
+
+        // Compute barycentric coordinates
+        float lambda0 = 1 - t;
+        float lambda1 = t;
+
+        mask = (1u << i0 | 1u << i1); // binary mask for two coordinates
+        if (lambda0 < 0) mask = 1u << i1; // 0b0010;
+        else if (lambda1 < 0) mask = 1u << i0; //0b0001;
+
+        return a + Math.Clamp(t, 0.0f, 1.0f) * v;
+    }
+
+    private JVector ClosestTriangle(int i0, int i1, int i2, out uint mask)
+    {
+        mask = 0;
+
+        var ptr = (JVector*)Unsafe.AsPointer(ref this.v0);
+        JVector a = ptr[i0];
+        JVector b = ptr[i1];
+        JVector c = ptr[i2];
+
+        JVector.Subtract(a, b, out var u);
+        JVector.Subtract(a, c, out var v);
+
+        JVector normal = u % v;
+
+        float t = 1.0f / normal.LengthSquared();
+
+        JVector.Cross(u, a, out var c1);
+        JVector.Cross(a, v, out var c2);
+
+        float gamma = JVector.Dot(c1, normal) * t;
+        float beta = JVector.Dot(c2, normal) * t;
+        float alpha = 1.0f - gamma - beta;
+
+        float bestDistance = float.MaxValue;
+        Unsafe.SkipInit(out JVector closestPt);
+
+        if (alpha < 0.0f)
+        {
+            var closest = ClosestSegment(i1, i2, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        if (beta < 0.0f)
+        {
+            var closest = ClosestSegment(i0, i2, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        if (gamma < 0.0f)
+        {
+            var closest = ClosestSegment(i0, i1, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                closestPt = closest;
+            }
+        }
+
+        if (mask != 0) return closestPt;
+
+        mask = (1u << i0) | (1u << i1) | (1u << i2);
+        return alpha * a + beta * b + gamma * c;
+    }
+
+    public JVector ClosestTetrahedron(out uint mask)
+    {
+        float detT = 1.0f / Determinant(v0, v1, v2, v3);
+        float lambda0 = Determinant(JVector.Zero, v1, v2, v3) * detT;
+        float lambda1 = Determinant(v0, JVector.Zero, v2, v3) * detT;
+        float lambda2 = Determinant(v0, v1, JVector.Zero, v3) * detT;
+        float lambda3 = 1.0f - lambda0 - lambda1 - lambda2;
+
+        float bestDistance = float.MaxValue;
+        Unsafe.SkipInit(out JVector closestPt);
+
+        mask = 0;
+
+        if (lambda0 < 0.0f)
+        {
+            var closest = ClosestTriangle(1, 2, 3, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        if (lambda1 < 0.0f)
+        {
+            var closest = ClosestTriangle(0, 2, 3, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        if (lambda2 < 0.0f)
+        {
+            var closest = ClosestTriangle(0, 1, 3, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        if (lambda3 < 0.0f)
+        {
+            var closest = ClosestTriangle(0, 1, 2, out uint m);
+            float dist = closest.LengthSquared();
+            if (dist < bestDistance)
+            {
+                mask = m;
+                bestDistance = dist;
+                closestPt = closest;
+            }
+        }
+
+        return closestPt;
+    }
+
+
+
+    // Helper method to calculate determinant (scalar triple product)
+    private static float Determinant(JVector v0, JVector v1, JVector v2, JVector v3)
+    {
+        JVector v10 = v1 - v0;
+        JVector v20 = v2 - v0;
+        JVector v30 = v3 - v0;
+
+        return JVector.Dot(v10, JVector.Cross(v20, v30));
+    }
+
+    private void Shuffle(uint usedMask)
+    {
+        var ptr = (JVector*)Unsafe.AsPointer(ref this.v0);
+        useCount = 0;
+
+        if ((usedMask & 0b0001) != 0) ptr[useCount++] = v0;
+        if ((usedMask & 0b0010) != 0) ptr[useCount++] = v1;
+        if ((usedMask & 0b0100) != 0) ptr[useCount++] = v2;
+        if ((usedMask & 0b1000) != 0) ptr[useCount++] = v3;
+    }
+
+    public bool AddVertex(in JVector vertex, out JVector closest)
+    {
+        const float epsilon = 1e-8f;
+
+        Unsafe.SkipInit(out closest);
+
+        // If the vertex is not able to "extend" the simplex (in any dimension)
+        // we return false and do nothing.
+
+        var ptr = (JVector*)Unsafe.AsPointer(ref this.v0);
+        ptr[useCount++] = vertex;
+
+        uint usedMask;
+
+        switch (useCount)
+        {
+            case 1:
+            {
+                closest = v0;
+                return true;
+            }
+            case 2:
+            {
+                if ((v0 - v1).LengthSquared() < epsilon * epsilon)
+                {
+                    return false;
+                }
+
+                closest = ClosestSegment(0,1,out usedMask);
+                Shuffle(usedMask);
+
+                return true;
+            }
+            case 3:
+            {
+                JVector u = v0 - v2;
+                JVector v = v1 - v2;
+
+                if ((u % v).LengthSquared() < epsilon * epsilon)
+                {
+                    return false;
+                }
+
+                closest = ClosestTriangle(0, 1, 2, out usedMask);
+                Shuffle(usedMask);
+
+                return true;
+            }
+            case 4:
+            {
+                JVector u = v0 - v2;
+                JVector v = v1 - v2;
+
+                JVector normal = u % v;
+
+                if (MathF.Abs(JVector.Dot(normal, v3 - v0)) < epsilon)
+                {
+                    return false;
+                }
+
+                closest = ClosestTetrahedron(out usedMask);
+                if (usedMask == 0) return false;
+
+                Shuffle(usedMask);
+                return true;
+            }
+
+            default:
+                throw new Exception();
+        }
+    }
+}


### PR DESCRIPTION
Non-EPA code (PointTest, Raycast, SweepTest) does not need to build the full convex polytope in Minkowski space. This change introduces SimplexSolver and SimplexSolverAB which operates with simplexes with up to four (d+1) vertices.