### PR TITLE
Replace glNamedFramebufferDrawBuffer with glDrawBuffer in Framebuffer.cs

### DIFF
--- a/src/JitterDemo/Renderer/OpenGL/Native/GL.cs
+++ b/src/JitterDemo/Renderer/OpenGL/Native/GL.cs
@@ -83,9 +83,9 @@ public static class GL
 
     private static glFramebufferTexture2DDelegate glFramebufferTexture2D;
 
-    private delegate void glNamedFramebufferDrawBufferDelegate(uint framebuffer, uint buf);
+    private delegate void glDrawBufferDelegate(uint buf);
 
-    private static glNamedFramebufferDrawBufferDelegate glNamedFramebufferDrawBuffer;
+    private static glDrawBufferDelegate glDrawBuffer;
 
     private delegate void glBindBufferDelegate(uint target, uint buffer);
 
@@ -338,7 +338,7 @@ public static class GL
         glDebugMessageCallback = GetDelegate<glDebugMessageCallbackDelegate>();
         glGenerateMipmap = GetDelegate<glGenerateMipmapDelegate>();
         glBindBuffer = GetDelegate<glBindBufferDelegate>();
-        glNamedFramebufferDrawBuffer = GetDelegate<glNamedFramebufferDrawBufferDelegate>();
+        glDrawBuffer = GetDelegate<glDrawBufferDelegate>();
         glFramebufferTexture2D = GetDelegate<glFramebufferTexture2DDelegate>();
         glBindFramebuffer = GetDelegate<glBindFramebufferDelegate>();
         glGenBuffers = GetDelegate<glGenBuffersDelegate>();
@@ -547,9 +547,9 @@ public static class GL
         glBindBuffer(target, buffer);
     }
 
-    public static void NamedFramebufferDrawBuffer(uint framebuffer, uint buf)
+    public static void DrawBuffer(uint buf)
     {
-        glNamedFramebufferDrawBuffer(framebuffer, buf);
+        glDrawBuffer(buf);
     }
 
     public static void FramebufferTexture2D(uint target, uint attachment, uint textarget, uint texture, int level)

--- a/src/JitterDemo/Renderer/OpenGL/Objects/Framebuffer.cs
+++ b/src/JitterDemo/Renderer/OpenGL/Objects/Framebuffer.cs
@@ -46,6 +46,6 @@ public class FrameBuffer : GLObject
     {
         Bind();
         GL.FramebufferTexture2D(GLC.FRAMEBUFFER, GLC.DEPTH_ATTACHMENT, GLC.TEXTURE_2D, texture.Handle, 0);
-        GL.NamedFramebufferDrawBuffer(Handle, GLC.NONE);
+        GL.DrawBuffer(GLC.NONE);
     }
 }


### PR DESCRIPTION
https://registry.khronos.org/OpenGL-Refpages/gl4/html/glDrawBuffer.xhtml

Version Support
	OpenGL Version
Function / Feature Name 	2.0 	2.1 	3.0 	3.1 	3.2 	3.3 	4.0 	4.1 	4.2 	4.3 	4.4 	4.5
glDrawBuffer 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔ 	✔
glNamedFramebufferDrawBuffer 	- 	- 	- 	- 	- 	- 	- 	- 	- 	- 	- 	✔