### PR TITLE
Add IslandActivated and IslandDeactivated events to World

### DIFF
--- a/src/Jitter2/World.Step.cs
+++ b/src/Jitter2/World.Step.cs
@@ -1119,7 +1119,7 @@ public sealed partial class World
         }
     }
 
-    private readonly Stack<Island> inactivateIslands = new();
+    private readonly Stack<(Island Island, bool RaiseEvent)> inactivateIslands = new();
 
     private void CheckDeactivation()
     {
@@ -1139,6 +1139,9 @@ public sealed partial class World
             island.NeedsUpdate = false;
 
             if (!deactivateIsland && !needsUpdate) continue;
+
+            bool activatedBody = false;
+            bool deactivatedBody = false;
 
             foreach (RigidBody body in island.InternalBodies)
             {
@@ -1162,6 +1165,8 @@ public sealed partial class World
                     // of static bodies, as the island of the static body goes to sleep.
                     if (body.MotionType != MotionType.Static)
                     {
+                        deactivatedBody = true;
+                        
                         foreach (var c in body.InternalContacts)
                         {
                             memContacts.MoveToInactive(c.Handle);
@@ -1191,6 +1196,7 @@ public sealed partial class World
                     if (rigidBody.MotionType == MotionType.Static) continue;
 
                     rigidBody.IsActive = true;
+                    activatedBody = true;
 
                     body.InternalSleepTime = 0;
 
@@ -1221,13 +1227,21 @@ public sealed partial class World
                 }
             }
 
-            if (deactivateIsland) inactivateIslands.Push(island);
+            if (deactivateIsland)
+            {
+                inactivateIslands.Push((island, deactivatedBody));
+            }
+            else if (activatedBody)
+            {
+                IslandActivated?.Invoke(island);
+            }
         }
 
         while (inactivateIslands.Count > 0)
         {
-            Island island = inactivateIslands.Pop();
+            var (island, raiseEvent) = inactivateIslands.Pop();
             islands.MoveToInactive(island);
+            if (raiseEvent) IslandDeactivated?.Invoke(island);
         }
     }
 }

--- a/src/Jitter2/World.cs
+++ b/src/Jitter2/World.cs
@@ -170,6 +170,36 @@ public sealed partial class World : IDisposable
     public event WorldStep? PostSubStep;
 
     /// <summary>
+    /// Raised when inactive non-static bodies in a simulation island are activated during a simulation step.
+    /// </summary>
+    /// <remarks>
+    /// This event is invoked after the island's non-static bodies, contacts, constraints, and
+    /// shapes have been moved to the active partition. Island instances are internal
+    /// connectivity objects and may later split, merge, or be reused; copy any data you
+    /// need during the callback instead of caching the island reference.
+    /// Do not perform topology-changing world modifications here (for example
+    /// adding or removing bodies, constraints, or contacts, or changing body
+    /// motion types).
+    /// </remarks>
+    [CallbackThread(ThreadContext.MainThread)]
+    public event Action<Island>? IslandActivated;
+
+    /// <summary>
+    /// Raised when active non-static bodies in a simulation island are deactivated during a simulation step.
+    /// </summary>
+    /// <remarks>
+    /// This event is invoked after the island's non-static bodies, contacts, constraints, and
+    /// shapes have been moved to the inactive partition. Island instances are internal
+    /// connectivity objects and may later split, merge, or be reused; copy any data you
+    /// need during the callback instead of caching the island reference.
+    /// Do not perform topology-changing world modifications here (for example
+    /// adding or removing bodies, constraints, or contacts, or changing body
+    /// motion types).
+    /// </remarks>
+    [CallbackThread(ThreadContext.MainThread)]
+    public event Action<Island>? IslandDeactivated;
+
+    /// <summary>
     /// Grants access to objects residing in unmanaged memory. This operation can be potentially unsafe. Use
     /// the corresponding managed properties where possible to mitigate risk.
     /// </summary>

--- a/src/JitterTests/Behavior/SleepTests.cs
+++ b/src/JitterTests/Behavior/SleepTests.cs
@@ -243,4 +243,74 @@ public class SleepTests
         world.Dispose();
     }
 
+    [TestCase]
+    public void IslandDeactivatedEventIsRaisedAfterIslandSleeps()
+    {
+        var world = new World();
+        world.Gravity = JVector.Zero;
+
+        var body = world.CreateRigidBody();
+        body.AddShape(new BoxShape(1));
+        body.DeactivationTime = TimeSpan.FromSeconds(1);
+
+        int deactivated = 0;
+        bool callbackSawBody = false;
+        bool callbackSawInactiveBody = false;
+        bool callbackSawInactivePartition = false;
+
+        world.IslandDeactivated += island =>
+        {
+            deactivated++;
+            callbackSawBody = island.Bodies.Contains(body);
+            callbackSawInactiveBody = !body.IsActive;
+            callbackSawInactivePartition = !world.Islands.IsActive(island);
+        };
+
+        Helper.AdvanceWorld(world, 2, (Real)(1.0 / 100.0), false);
+
+        Assert.That(deactivated, Is.EqualTo(1));
+        Assert.That(callbackSawBody, Is.True);
+        Assert.That(callbackSawInactiveBody, Is.True);
+        Assert.That(callbackSawInactivePartition, Is.True);
+
+        world.Dispose();
+    }
+
+    [TestCase]
+    public void IslandActivatedEventIsRaisedAfterSleepingIslandWakes()
+    {
+        var world = new World();
+        world.Gravity = JVector.Zero;
+
+        var body = world.CreateRigidBody();
+        body.AddShape(new BoxShape(1));
+        body.DeactivationTime = TimeSpan.FromSeconds(1);
+
+        Helper.AdvanceWorld(world, 2, (Real)(1.0 / 100.0), false);
+        Assert.That(body.IsActive, Is.False);
+
+        int activated = 0;
+        bool callbackSawBody = false;
+        bool callbackSawActiveBody = false;
+        bool callbackSawActivePartition = false;
+
+        world.IslandActivated += island =>
+        {
+            activated++;
+            callbackSawBody = island.Bodies.Contains(body);
+            callbackSawActiveBody = body.IsActive;
+            callbackSawActivePartition = world.Islands.IsActive(island);
+        };
+
+        body.SetActivationState(true);
+        world.Step((Real)(1.0 / 100.0), false);
+
+        Assert.That(activated, Is.EqualTo(1));
+        Assert.That(callbackSawBody, Is.True);
+        Assert.That(callbackSawActiveBody, Is.True);
+        Assert.That(callbackSawActivePartition, Is.True);
+
+        world.Dispose();
+    }
+
 }


### PR DESCRIPTION
  ## Summary

  Adds two new `World` events for observing simulation island sleep state transitions:

  - `World.IslandActivated`
  - `World.IslandDeactivated`

  These events are raised when non-static bodies in an island transition between inactive and active state during the deactivation/update pass.

  ## Details

  The events expose island activation changes without requiring users to poll body state manually. This is useful for systems that need to
  react to sleeping/waking islands, such as networking, persistence, or debug visualization.

  Event timing:

  - `IslandActivated` is raised after the island’s non-static bodies, contacts, constraints, and shapes have been moved to the active
  partition.
  - `IslandDeactivated` is raised after the island has been moved to the inactive partition.
  - Static-only island transitions do not raise these events.

  The XML docs also note that `Island` instances are internal connectivity objects and should not be cached long-term.
